### PR TITLE
Add basic Qt GUI for package manager wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16)
+project(PackageManagerGUI)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
+
+add_executable(package-manager-gui src/main.cpp)
+target_link_libraries(package-manager-gui Qt5::Widgets)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-ss
+# Package Manager GUI
+
+Simple Qt-based C++ application that exposes a minimal interface for installing software using package managers such as Winget, Chocolatey, and npm.
+
+## Building
+
+This project requires Qt 5 development libraries.
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+## Usage
+
+Run the compiled `package-manager-gui` binary. Enter a package name, choose the package manager, and press **Install**. Command output will be displayed in the text area.
+
+Because Winget and Chocolatey are Windows-specific, the corresponding commands will only work on Windows systems with those tools installed.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,66 @@
+#include <QApplication>
+#include <QWidget>
+#include <QPushButton>
+#include <QLineEdit>
+#include <QComboBox>
+#include <QVBoxLayout>
+#include <QTextEdit>
+#include <QProcess>
+
+class MainWindow : public QWidget {
+public:
+    MainWindow() {
+        auto *layout = new QVBoxLayout(this);
+        combo = new QComboBox(this);
+        combo->addItem("winget");
+        combo->addItem("choco");
+        combo->addItem("npm");
+        layout->addWidget(combo);
+
+        input = new QLineEdit(this);
+        input->setPlaceholderText("Package name");
+        layout->addWidget(input);
+
+        output = new QTextEdit(this);
+        output->setReadOnly(true);
+        layout->addWidget(output);
+
+        auto *button = new QPushButton("Install", this);
+        layout->addWidget(button);
+
+        QObject::connect(button, &QPushButton::clicked, [this]() { runCommand(); });
+    }
+
+private:
+    void runCommand() {
+        QString pkg = input->text();
+        if (pkg.isEmpty()) return;
+
+        QString manager = combo->currentText();
+        QStringList args;
+        if (manager == "winget") {
+            args << "install" << pkg;
+        } else if (manager == "choco") {
+            args << "install" << pkg << "-y";
+        } else if (manager == "npm") {
+            args << "install" << "-g" << pkg;
+        }
+
+        QProcess proc;
+        proc.start(manager, args);
+        proc.waitForFinished();
+        output->append(proc.readAllStandardOutput());
+        output->append(proc.readAllStandardError());
+    }
+
+    QComboBox *combo;
+    QLineEdit *input;
+    QTextEdit *output;
+};
+
+int main(int argc, char **argv) {
+    QApplication app(argc, argv);
+    MainWindow w;
+    w.show();
+    return app.exec();
+}


### PR DESCRIPTION
## Summary
- Add Qt-based C++ GUI that runs winget, choco, or npm commands
- Document build and usage instructions
- Provide CMake build configuration

## Testing
- `cmake -S . -B build` (fails: Could not find Qt5)
- `cmake --build build` (fails: No rule to make target 'Makefile')

------
https://chatgpt.com/codex/tasks/task_b_68ae7b0166348321901d62af84ae75f7