### PR TITLE
Switch to FLTK for GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ project(PackageManagerGUI)
 
 set(CMAKE_CXX_STANDARD 17)
 
-find_package(Qt5 COMPONENTS Widgets REQUIRED)
+find_package(FLTK REQUIRED)
 
 add_executable(package-manager-gui src/main.cpp)
-target_link_libraries(package-manager-gui Qt5::Widgets)
+target_include_directories(package-manager-gui PRIVATE ${FLTK_INCLUDE_DIR})
+target_link_libraries(package-manager-gui PRIVATE ${FLTK_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Package Manager GUI
 
-Simple Qt-based C++ application that exposes a minimal interface for installing software using package managers such as Winget, Chocolatey, and npm.
+Simple FLTK-based C++ application that exposes a minimal interface for installing software using package managers such as Winget, Chocolatey, and npm.
 
 ## Building
 
-This project requires Qt 5 development libraries.
+This project requires FLTK development libraries (e.g. `libfltk1.3-dev`).
 
 ```bash
 mkdir build


### PR DESCRIPTION
## Summary
- Replace Qt5 dependency with FLTK in the build system.
- Reimplement GUI using FLTK widgets and subprocess capture.
- Update documentation to mention FLTK requirements.

## Testing
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `cmake -S . -B build` *(fails: Could NOT find FLTK (missing: FLTK_LIBRARIES FLTK_INCLUDE_DIR FLTK_FLUID_EXECUTABLE))*

------
https://chatgpt.com/codex/tasks/task_b_68ae8302c2a88321baa724f44211b5c3